### PR TITLE
fix: search for the commit in the whole git repo

### DIFF
--- a/lib/deps_nix/fetch_git.ex
+++ b/lib/deps_nix/fetch_git.ex
@@ -13,6 +13,7 @@ defmodule DepsNix.FetchGit do
       builtins.fetchGit {
         url = "#{g.url}";
         rev = "#{g.rev}";
+        allRefs = true;
       };\
       """
     end


### PR DESCRIPTION
Hello 👋 

Thank you for your work on this 👍

By default `fetchGit` will only search for the commit on the default branch, but on mix side it not possible to set a branch and a commit, one can only have one of `branch`, `tag`, or `ref`. So it's not possible to get a specific commit from a specific branch in this situation.

This patch activates the "allRefs" option of fetchGit so that the commit will be searched in the whole repo and not only in the default branch.