### PR TITLE
Remove darwin.IOKit stubs; they no longer do anything.

### DIFF
--- a/fixtures/example/deps.nix
+++ b/fixtures/example/deps.nix
@@ -47,7 +47,7 @@ let
               };
               nativeBuildInputs = [
                 extendedPkgs.cmake
-              ] ++ extendedPkgs.lib.lists.optional extendedPkgs.stdenv.isDarwin extendedPkgs.darwin.IOKit;
+              ];
               doCheck = false;
             };
 

--- a/lib/deps_nix.ex
+++ b/lib/deps_nix.ex
@@ -241,7 +241,7 @@ defmodule DepsNix do
                     };
                     nativeBuildInputs = [
                       extendedPkgs.cmake
-                    ] ++ extendedPkgs.lib.lists.optional extendedPkgs.stdenv.isDarwin extendedPkgs.darwin.IOKit;
+                    ];
                     doCheck = false;
                   };
 


### PR DESCRIPTION
    evaluation warning: darwin.IOKit: these stubs do nothing and will be removed in Nixpkgs 25.11;
    see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation and migration
    instructions.