### PR TITLE
Permit overriding the Fenix overlay used.

### DIFF
--- a/fixtures/example/deps.nix
+++ b/fixtures/example/deps.nix
@@ -3,6 +3,7 @@
   lib,
   beamPackages,
   overrides ? (x: y: { }),
+  overrideFenixOverlay ? null,
 }:
 
 let
@@ -22,12 +23,16 @@ let
       old:
       let
         extendedPkgs = pkgs.extend fenixOverlay;
-        fenixOverlay = import "${
-          fetchTarball {
-            url = "https://github.com/nix-community/fenix/archive/056c9393c821a4df356df6ce7f14c722dc8717ec.tar.gz";
-            sha256 = "sha256:1cdfh6nj81gjmn689snigidyq7w98gd8hkl5rvhly6xj7vyppmnd";
-          }
-        }/overlay.nix";
+        fenixOverlay =
+          if overrideFenixOverlay == null then
+            import "${
+              fetchTarball {
+                url = "https://github.com/nix-community/fenix/archive/056c9393c821a4df356df6ce7f14c722dc8717ec.tar.gz";
+                sha256 = "sha256:1cdfh6nj81gjmn689snigidyq7w98gd8hkl5rvhly6xj7vyppmnd";
+              }
+            }/overlay.nix"
+          else
+            overrideFenixOverlay;
         nativeDir = "${old.src}/native/${with builtins; head (attrNames (readDir "${old.src}/native"))}";
         fenix =
           if toolchain == null then

--- a/lib/deps_nix.ex
+++ b/lib/deps_nix.ex
@@ -197,6 +197,7 @@ defmodule DepsNix do
         lib,
         beamPackages,
         overrides ? (x: y: { }),
+        overrideFenixOverlay ? null,
       }:
 
       let
@@ -216,12 +217,16 @@ defmodule DepsNix do
             old:
             let
               extendedPkgs = pkgs.extend fenixOverlay;
-              fenixOverlay = import "${
-                fetchTarball {
-                  url = "https://github.com/nix-community/fenix/archive/056c9393c821a4df356df6ce7f14c722dc8717ec.tar.gz";
-                  sha256 = "sha256:1cdfh6nj81gjmn689snigidyq7w98gd8hkl5rvhly6xj7vyppmnd";
-                }
-              }/overlay.nix";
+              fenixOverlay =
+                if overrideFenixOverlay == null then
+                  import "${
+                    fetchTarball {
+                      url = "https://github.com/nix-community/fenix/archive/056c9393c821a4df356df6ce7f14c722dc8717ec.tar.gz";
+                      sha256 = "sha256:1cdfh6nj81gjmn689snigidyq7w98gd8hkl5rvhly6xj7vyppmnd";
+                    }
+                  }/overlay.nix"
+                else
+                  overrideFenixOverlay;
               nativeDir = "${old.src}/native/${with builtins; head (attrNames (readDir "${old.src}/native"))}";
               fenix =
                 if toolchain == null then


### PR DESCRIPTION
Hiya!

My Rust NIFs depend on rustc 1.86, but the current version of Fenix used in deps_nix supplies 1.84.

Instead of just bumping it again, I thought it might be nice to allow the user to supply the Fenix overlay themselves, if it affects them. Then they can manage how they source it and which version it is.

(Currently using this branch on my own projects successfully!)