### PR TITLE
Patch lib extname to .so for apple-darwin

### DIFF
--- a/fixtures/example/deps.nix
+++ b/fixtures/example/deps.nix
@@ -67,7 +67,11 @@ let
           mkdir -p priv/native
           for lib in ${native}/lib/*
           do
-            ln -s "$lib" "priv/native/$(basename "$lib")"
+            dest=$(basename "$lib")
+            if [ "''${dest##*.}" = "dylib" ]; then
+              dest="''${dest%.dylib}.so"
+            fi
+            ln -s "$lib" "priv/native/$dest"
           done
         '';
 

--- a/fixtures/example/package.nix
+++ b/fixtures/example/package.nix
@@ -1,0 +1,41 @@
+{
+  pkgs,
+  ...
+}:
+let
+  src = ./.;
+
+  erlang = pkgs.beam.interpreters.erlang_28;
+  beamUpstream = pkgs.beam.packagesWith erlang;
+  elixir = beamUpstream.elixir_1_19;
+
+  beamPackages = beamUpstream // rec {
+    inherit erlang elixir;
+    hex = beamUpstream.hex.override { inherit elixir; };
+    buildMix = beamUpstream.buildMix.override { inherit elixir erlang hex; };
+  };
+
+  mixNixDeps = pkgs.callPackages ./deps.nix {
+    beamPackages = beamPackages;
+  };
+in
+beamPackages.buildMix {
+  inherit
+    src
+    elixir
+    ;
+
+  name = "example";
+  version = "0.1.0";
+  mixEnv = "test";
+  doCheck = true;
+
+  nativeBuildInputs = [
+    pkgs.rustPackages.cargo
+    (builtins.attrValues mixNixDeps)
+  ];
+
+  checkPhase = ''
+    mix test --no-deps-check
+  '';
+}

--- a/fixtures/example/test/example_test.exs
+++ b/fixtures/example/test/example_test.exs
@@ -2,7 +2,7 @@ defmodule ExampleTest do
   use ExUnit.Case
   doctest Example
 
-  test "greets the world" do
-    assert Example.hello() == :world
+  test "runs simple Explorer example" do
+    assert Explorer.Series.from_list(["apple", "mango", "banana", "orange"])
   end
 end

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,13 @@
         ] (system: generate { pkgs = import nixpkgs { inherit system; }; });
     in
     {
-      packages = forAllSystems ({ pkgs, ... }: (pkgs.callPackages ./fixtures/example/deps.nix { }));
+      packages = forAllSystems (
+        { pkgs, ... }:
+        (pkgs.callPackages ./fixtures/example/deps.nix { })
+        // {
+          example = pkgs.callPackage ./fixtures/example/package.nix { };
+        }
+      );
 
       devShells = forAllSystems (
         { pkgs, ... }:

--- a/lib/deps_nix.ex
+++ b/lib/deps_nix.ex
@@ -276,7 +276,11 @@ defmodule DepsNix do
                 mkdir -p priv/native
                 for lib in ${native}/lib/*
                 do
-                  ln -s "$lib" "priv/native/$(basename "$lib")"
+                  dest=$(basename "$lib")
+                  if [ "''${dest##*.}" = "dylib" ]; then
+                    dest="''${dest%.dylib}.so"
+                  fi
+                  ln -s "$lib" "priv/native/$dest"
                 done
               '';
 


### PR DESCRIPTION
Closes #31

On apple-darwin, libraries are compiled as `*.dylib`, though Rustler expects a `*.so` extname.  This patch updates the library name symlinked in `preConfigure` to match what Rustler expects when loading the file at runtime.