### PR TITLE
feat(deps_nix): Add rustler precompiled overrides to deps_nix

### DIFF
--- a/lib/deps_nix.ex
+++ b/lib/deps_nix.ex
@@ -216,6 +216,7 @@ defmodule DepsNix do
         fetchFromGitHub,
         overrides ? (x: y: { }),
         overrideFenixOverlay ? null,
+        rustlerPrecompiledOverrides ? { },
         pkg-config,
         vips,
         writeText,
@@ -255,9 +256,10 @@ defmodule DepsNix do
                 else
                   extendedPkgs.fenix.fromToolchainName toolchain;
               native =
-                (extendedPkgs.makeRustPlatform {
-                  inherit (fenix) cargo rustc;
-                }).buildRustPackage
+                (
+                  (extendedPkgs.makeRustPlatform {
+                    inherit (fenix) cargo rustc;
+                  }).buildRustPackage
                   {
                     pname = "${old.packageName}-native";
                     version = old.version;
@@ -269,7 +271,9 @@ defmodule DepsNix do
                       extendedPkgs.cmake
                     ];
                     doCheck = false;
-                  };
+                  }
+                ).overrideAttrs
+                  rustlerPrecompiledOverrides.${old.packageName} or { };
 
             in
             {


### PR DESCRIPTION
fix #20 

```nix
mixNixDeps = pkgs.callPackages ./deps.nix {
    rustlerPrecompiledOverrides = {
      vega_lite_convert = {
        env.RUSTY_V8_ARCHIVE = pkgs.fetchurl {
          url = "https://github.com/denoland/rusty_v8/releases/download/v0.105.1/librusty_v8_release_x86_64-unknown-linux-gnu.a.gz";
          hash = "sha256-f7aDA74Jn2h4rp9sACGHX4DBbN6yevgWCEKdfI1fJDU=";
        };
        postInstall = ''
          # this package does not expect lib prefix
          ln -s libex_vl_convert.so $out/lib/ex_vl_convert.so
        '';
      };
    };
  };
```