### PR TITLE
Make compile-time config optional

### DIFF
--- a/lib/deps_nix.ex
+++ b/lib/deps_nix.ex
@@ -7,6 +7,7 @@ defmodule DepsNix do
             envs: map(),
             github_prefetcher: (String.t(), String.t(), String.t() -> String.t()),
             output: String.t(),
+            app_config: boolean(),
             app_config_path: String.t() | nil,
             include_paths: boolean(),
             cwd: String.t()
@@ -14,6 +15,7 @@ defmodule DepsNix do
     defstruct envs: %{},
               github_prefetcher: nil,
               output: "deps.nix",
+              app_config: true,
               app_config_path: nil,
               include_paths: false,
               cwd: nil
@@ -63,6 +65,7 @@ defmodule DepsNix do
       strict: [
         env: [:string, :keep],
         output: :string,
+        app_config: :boolean,
         app_config_path: :string,
         include_paths: :boolean
       ]
@@ -174,6 +177,7 @@ defmodule DepsNix do
             end
           end,
         include_paths: Keyword.get(opts, :include_paths, false),
+        app_config: Keyword.get(opts, :app_config, true),
         app_config_path: Keyword.get(opts, :app_config_path, nil)
     }
     |> add_output(opts)

--- a/lib/deps_nix/derivation.ex
+++ b/lib/deps_nix/derivation.ex
@@ -138,6 +138,8 @@ defmodule DepsNix.Derivation do
   ## Instead, we need to use fetchgit, so that private keys can be used
   defp parse_git_url(url, _private = true), do: url
 
+  defp app_config_path(%DepsNix.Options{app_config: false}), do: nil
+
   defp app_config_path(opts) do
     if opts.app_config_path do
       opts.app_config_path
@@ -331,6 +333,10 @@ defmodule DepsNix.Derivation do
         true ->
           ""
       end
+    end
+
+    defp format_app_config_path(%DepsNix.Derivation{app_config_path: nil}) do
+      ""
     end
 
     defp format_app_config_path(%DepsNix.Derivation{

--- a/lib/mix/tasks/deps.nix.ex
+++ b/lib/mix/tasks/deps.nix.ex
@@ -39,6 +39,22 @@ defmodule Mix.Tasks.Deps.Nix do
   mix deps.nix --include-paths --env prod --env dev=ex_doc,credo --output nix/deps.nix --app-config-path ./my-app/config
   ```
 
+  ## Application config
+
+  By default, every `buildMix` derivation is given an `appConfigPath` pointing
+  at your application's `config` directory, so that dependencies see your
+  compile-time configuration. This means a change to any config file
+  invalidates every dependency and forces a recompile.
+
+  Pass `--no-app-config` to omit `appConfigPath` entirely. Dependencies then
+  build with an empty config and are no longer rebuilt when your config
+  changes. Individual dependencies that need compile-time config can be given
+  one back through the `overrides` argument of the generated file:
+
+  ```
+  some_dep = prev.some_dep.override { appConfigPath = ./config; };
+  ```
+
   ## Git dependencies
 
   `deps_nix` supports git dependencies.

--- a/test/deps_nix_test.exs
+++ b/test/deps_nix_test.exs
@@ -144,6 +144,14 @@ defmodule DepsNixTest do
              } = DepsNix.parse_args(~w(--app-config-path ../my/app/config))
     end
 
+    test "application config is passed by default" do
+      assert %DepsNix.Options{app_config: true} = DepsNix.parse_args(~w())
+    end
+
+    test "can disable passing of application config" do
+      assert %DepsNix.Options{app_config: false} = DepsNix.parse_args(~w(--no-app-config))
+    end
+
     defp package_name do
       string(:alphanumeric, min_length: 1)
     end
@@ -289,6 +297,18 @@ defmodule DepsNixTest do
              converger
            ) =~
              ~s(appConfigPath = ../my/app/config;)
+  end
+
+  test "can omit appConfigPath entirely" do
+    converger = fn _ -> [pick(dep())] end
+
+    refute output(
+             %DepsNix.Options{
+               envs: %{"prod" => :all},
+               app_config: false
+             },
+             converger
+           ) =~ "appConfigPath"
   end
 
   defp output(opts, converger \\ &stub_converger/1) do


### PR DESCRIPTION
Very few packages actually need compile-time config. Allow users to opt out by default, which saves unnecessary rebuilds during config changes.